### PR TITLE
Fix for IE8 objection notation

### DIFF
--- a/jquery.charactercounter.js
+++ b/jquery.charactercounter.js
@@ -63,9 +63,9 @@
         {
             var classString = options.counterCssClass;
 
-            if ( options.customFields.class )
+            if ( options.customFields['class'] )
             {
-                classString += " " + options.customFields.class;
+                classString += " " + options.customFields['class'];
                 delete options.customFields['class'];
             }
 


### PR DESCRIPTION
IE8 doesn't like dot notation some times when referencing object properties... yeah ie8 sucks.
